### PR TITLE
Feat/修正部署heroku錯誤_設定SMTP及垃圾桶無法抓到信件內容

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -1,7 +1,6 @@
 class LettersController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_letter, only:[:show, :destroy]
-  before_action :current_user_email, only:[:starred, :trash]
+  before_action :current_user_email, only:[:index, :starred, :trash]
   before_action :show_label_list, only:[:index, :starred, :sendmail, :trash, :show]
 
   def index 
@@ -37,18 +36,16 @@ class LettersController < ApplicationController
   end
 
   def show
+    @letter = Letter.with_deleted.includes(:rich_text_content).find(params[:id])
   end
 
   def destroy
+    @letter = Letter.find(params[:id])
     @letter.destroy
     redirect_back(fallback_location: letter_path)
   end
 
   private
-  def find_letter
-    @letter = Letter.find(params[:id])
-  end
-
   def letter_params
     params.require(:letter).permit(:sender, :recipient, :subject, :content, :body, :carbon_copy, :star, :blind_carbon_copy, :attachments, :deleted_at)
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,4 +120,13 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV["smtp_address"],
+    port:                 587,
+    domain:               "@yimails.com",
+    user_name:            ENV["smtp_user_name"],
+    password:             ENV["smtp_password"],
+    authentication:       "plain",
+    enable_starttls_auto: true  }
 end

--- a/config/initializers/action_text.rb
+++ b/config/initializers/action_text.rb
@@ -1,5 +1,5 @@
 Rails.configuration.after_initialize do
   ActionText::RichText.class_eval do
-    acts_as_paranoid
+    acts_as_paranoid without_default_scope: true
   end
 end


### PR DESCRIPTION
1.到production設定SMTP
2.修改垃圾桶信件無法抓到信件內容