### PR TITLE
fix/關閉delayed_job

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,6 @@ module Yimails
     # config.eager_load_paths << Rails.root.join("extras")
 
     # active_storage.replace_on_assign_to_many = false
-    config.active_job.queue_adapter = :delayed_job
+    # config.active_job.queue_adapter = :delayed_job
   end
 end


### PR DESCRIPTION
因使用delayed_job會造成信件無法確實寄出，故先關閉delayed_job